### PR TITLE
Update README.md to recommend Nix-based direnv installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,13 +15,8 @@ Before getting started, you'll need:
 2. **direnv** for automatic environment activation:
 
    ```bash
-   # On macOS (via Homebrew)
-   brew install direnv
-
-   # On Linux (via package manager)
-   # Ubuntu/Debian: apt install direnv
-   # Arch: pacman -S direnv
-   # Fedora: dnf install direnv
+   # Install via Nix (recommended for consistency with project setup)
+   nix profile install nixpkgs#direnv
    ```
 
 3. **Configure direnv** in your shell (add to `~/.bashrc`, `~/.zshrc`, etc.):


### PR DESCRIPTION
Replace platform-specific package manager instructions with a single
Nix-based installation command for consistency with the project's
Nix-first development environment approach.

Fixes #3

Generated with [Claude Code](https://claude.ai/code)